### PR TITLE
Add primary and secondary site links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # kalendar
 CB/PMR/HAM kalendář akcí a závodů
 
+## Odkazy na stránky
+- Primární: https://podly27.github.io/CB-PMR-HAM-kalendar/
+- Sekundární: https://kalendar.svysilackou.cz/
+
 ## Rychlá analýza projektu
 Tento repozitář obsahuje statickou stránku publikovanou přes GitHub Pages. Jádrem je jediný HTML soubor s vloženými Google Calendar embed odkazy, doplněný o jednoduché CSS a ikonky pro URL/iCal odkazy. Stránka slouží jako rozcestník pro více tematických kalendářů a nabízí i kopírování iCal URL přímo z UI. Z technického pohledu jde o jednoduchý statický web bez build procesu, takže údržba spočívá hlavně v aktualizaci odkazů, textů a stylů.
 


### PR DESCRIPTION
### Motivation
- Provide direct links to the deployed sites so readers can quickly access the primary and fallback pages.

### Description
- Updated `README.md` to add a new "Odkazy na stránky" section containing the primary URL `https://podly27.github.io/CB-PMR-HAM-kalendar/` and the secondary URL `https://kalendar.svysilackou.cz/`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697202ec7560832b9ff5748e5882834f)