### PR TITLE
Render calendar embeds from single JS structure; improve accessibility, responsive layout, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ Tento repozitář obsahuje statickou stránku publikovanou přes GitHub Pages. J
 - `_config.yml` – konfigurace GitHub Pages/Jekyll (např. theme a SEO).
 - Ikony a favicona (`ical-icon.png`, `url-icon.png`, `favicon.ico`).
 
-## TODO návrhy na úpravy
-- [ ] **Zjednodušit embed část** – vytvořit přehledný seznam kalendářů z jedné datové struktury (např. JSON v JS) a generovat karty/iframe dynamicky, aby se minimalizovala duplicita HTML.
-- [ ] **Lepší přístupnost** – doplnit popisky/aria-labely u tlačítek a odkazů, sjednotit heading hierarchii a upravit kontrasty v CSS.
-- [ ] **Responzivní layout** – vylepšit chování na mobilech (např. změnit tabulku mini-kalendářů na stacking karty).
-- [ ] **Dokumentace** – přidat do README sekci „Jak aktualizovat kalendáře“ a „Jak nasadit na GitHub Pages“.
+## Jak aktualizovat kalendáře
+Kalendáře jsou definované v `index.html` jako jedna datová struktura v JavaScriptu (pole `calendars`). Pokud potřebujete přidat nebo upravit položku:
+1. Otevřete `index.html` a najděte sekci se skriptem `calendars`.
+2. Přidejte/aktualizujte objekt s názvem, `embedSrc`, `icalSrc` a `agendaSrc`.
+3. Uložte soubor a případně zkontrolujte výsledný layout v prohlížeči.
+
+## Jak nasadit na GitHub Pages
+Tento projekt je statický a běží na GitHub Pages bez build kroku.
+1. Pushněte změny do hlavní větve repozitáře.
+2. V nastavení repozitáře otevřete **Settings → Pages**.
+3. Zkontrolujte, že je zdroj nastaven na hlavní větev (root).
+4. Počkejte na deploy – URL bude odpovídat nastavení v Pages.
+
+## Další možné úpravy
 - [ ] **Monitoring odkazů** – krátký skript nebo GitHub Action, která ověří dostupnost iCal/URL odkazů.

--- a/custom.css
+++ b/custom.css
@@ -31,7 +31,7 @@
   border: 1px solid rgba(27, 31, 36, 0.15);
   border-radius: 12px;
   padding: 12px 12px 10px;
-  background: rgba(255, 255, 255, 0.7);
+  background: #ffffff;
 }
 
 .calendar-card h3 {
@@ -52,16 +52,17 @@
   gap: 6px;
   padding: 6px 10px;
   border-radius: 10px;
-  border: 1px solid rgba(27, 31, 36, 0.2);
-  background: #fff;
-  color: inherit;
+  border: 1px solid rgba(31, 35, 40, 0.35);
+  background: #f6f8fa;
+  color: #1f2328;
   text-decoration: none;
   font-size: 14px;
   line-height: 1.2;
 }
 
 .btn:hover {
-  border-color: rgba(27, 31, 36, 0.35);
+  border-color: rgba(31, 35, 40, 0.6);
+  background: #eef1f4;
   text-decoration: none;
 }
 
@@ -76,10 +77,54 @@
 .copy-status {
   margin-left: 6px;
   font-size: 13px;
-  opacity: 0.75;
+  color: #4b5563;
 }
 
-/* On phones: make the main embed a bit shorter and hide mini-embeds table. */
+.section-divider {
+  border: 0;
+  border-top: 1px solid rgba(31, 35, 40, 0.15);
+  margin: 20px 0;
+}
+
+.calendar-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin: 12px 0 0;
+}
+
+.calendar-mini-card {
+  border: 1px solid rgba(27, 31, 36, 0.15);
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.calendar-mini-card h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.calendar-mini-links {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.calendar-mini-links img {
+  display: block;
+}
+
+.calendar-mini-card iframe {
+  width: 100%;
+  min-height: 320px;
+  border: 0;
+}
+
+/* On phones: make the main embed a bit shorter and stack mini cards comfortably. */
 @media (max-width: 900px) {
   .calendar-main iframe {
     height: 66vh;
@@ -94,9 +139,8 @@
     border-radius: 8px;
   }
 
-  .calendar-mini-table {
-    display: none;
+  .calendar-mini-grid {
+    grid-template-columns: 1fr;
   }
 }
-
 

--- a/index.html
+++ b/index.html
@@ -52,8 +52,10 @@
             <iframe title="CB/PMR/HAM kalendář (souhrn)" src="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&src=aHU5YmpkaHZpOGExZ2dmMm1oNmN2ODUzaWtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=ZW85OGM1Y2hlcnVzMGlha212djJtZjBuODRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=aXU0NGtwa2llNXY0NHBkYzFrbzBwNmxjM2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=MGg2MmVvamhkZmpvaG9vMTVibGdqZmlhZzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=bXVnYTU3dThuMGMxcTJtNmtqZXUxMWc5bmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=Y3MuY3plY2gjaG9saWRheUBncm91cC52LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%233F51B5&color=%238E24AA&color=%23F09300&color=%23D81B60&color=%23EF6C00&color=%23009688" frameborder="0" scrolling="no"></iframe>
           </div>
           
-          <div class="calendar-main-link"><a href="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&src=aHU5YmpkaHZpOGExZ2dmMm1oNmN2ODUzaWtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=ZW85OGM1Y2hlcnVzMGlha212djJtZjBuODRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=aXU0NGtwa2llNXY0NHBkYzFrbzBwNmxjM2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=MGg2MmVvamhkZmpvaG9vMTVibGdqZmlhZzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=bXVnYTU3dThuMGMxcTJtNmtqZXUxMWc5bmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=Y3MuY3plY2gjaG9saWRheUBncm91cC52LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%233F51B5&color=%238E24AA&color=%23F09300&color=%23D81B60&color=%23EF6C00&color=%23009688">Přímý odkaz na kalendář</a></div>
-          <h2 id="line"> </h2>
+          <div class="calendar-main-link">
+            <a href="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&src=aHU5YmpkaHZpOGExZ2dmMm1oNmN2ODUzaWtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=ZW85OGM1Y2hlcnVzMGlha212djJtZjBuODRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=aXU0NGtwa2llNXY0NHBkYzFrbzBwNmxjM2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=MGg2MmVvamhkZmpvaG9vMTVibGdqZmlhZzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=bXVnYTU3dThuMGMxcTJtNmtqZXUxMWc5bmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=Y3MuY3plY2gjaG9saWRheUBncm91cC52LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%233F51B5&color=%238E24AA&color=%23F09300&color=%23D81B60&color=%23EF6C00&color=%23009688" aria-label="Přímý odkaz na souhrnný kalendář CB/PMR/HAM">Přímý odkaz na kalendář</a>
+          </div>
+          <hr class="section-divider">
       
           <p></p>
 
@@ -71,86 +73,149 @@
           <p><strong>URL</strong> je odkaz pro prohlížeč, <strong>iCal</strong> pro jiné aplikace (iOS/Android/desktop). Pokud používáte Google Calendar, stačí kliknout na symbol “+” v pravém dolním rohu kalendáře.</p>
 
           <h3>Kalendáře (rychlé odkazy)</h3>
-          <div class="calendar-cards">
-            <div class="calendar-card">
-              <h3>Akce a srazy</h3>
-              <div class="calendar-actions">
-                <a class="btn" href="https://calendar.google.com/calendar/embed?src=hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com&amp;ctz=Europe%2FPrague">Otevřít</a>
-                <a class="btn" href="https://calendar.google.com/calendar/ical/hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com/public/basic.ics">iCal</a>
-                <button class="btn btn-copy" type="button" data-copy="https://calendar.google.com/calendar/ical/hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com/public/basic.ics">Copy iCal</button>
-                <span class="copy-status" aria-live="polite"></span>
-              </div>
-            </div>
-            <div class="calendar-card">
-              <h3>CB závody</h3>
-              <div class="calendar-actions">
-                <a class="btn" href="https://calendar.google.com/calendar/embed?src=eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com&amp;ctz=Europe%2FPrague">Otevřít</a>
-                <a class="btn" href="https://calendar.google.com/calendar/ical/eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com/public/basic.ics">iCal</a>
-                <button class="btn btn-copy" type="button" data-copy="https://calendar.google.com/calendar/ical/eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com/public/basic.ics">Copy iCal</button>
-                <span class="copy-status" aria-live="polite"></span>
-              </div>
-            </div>
-            <div class="calendar-card">
-              <h3>PMR závody</h3>
-              <div class="calendar-actions">
-                <a class="btn" href="https://calendar.google.com/calendar/embed?src=0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com&amp;ctz=Europe%2FPrague">Otevřít</a>
-                <a class="btn" href="https://calendar.google.com/calendar/ical/0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com/public/basic.ics">iCal</a>
-                <button class="btn btn-copy" type="button" data-copy="https://calendar.google.com/calendar/ical/0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com/public/basic.ics">Copy iCal</button>
-                <span class="copy-status" aria-live="polite"></span>
-              </div>
-            </div>
-            <div class="calendar-card">
-              <h3>KV závody</h3>
-              <div class="calendar-actions">
-                <a class="btn" href="https://calendar.google.com/calendar/embed?src=iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com&amp;ctz=Europe%2FPrague">Otevřít</a>
-                <a class="btn" href="https://calendar.google.com/calendar/ical/iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com/public/basic.ics">iCal</a>
-                <button class="btn btn-copy" type="button" data-copy="https://calendar.google.com/calendar/ical/iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com/public/basic.ics">Copy iCal</button>
-                <span class="copy-status" aria-live="polite"></span>
-              </div>
-            </div>
-            <div class="calendar-card">
-              <h3>VKV, UKV závody</h3>
-              <div class="calendar-actions">
-                <a class="btn" href="https://calendar.google.com/calendar/embed?src=muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com&amp;ctz=Europe%2FPrague">Otevřít</a>
-                <a class="btn" href="https://calendar.google.com/calendar/ical/muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com/public/basic.ics">iCal</a>
-                <button class="btn btn-copy" type="button" data-copy="https://calendar.google.com/calendar/ical/muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com/public/basic.ics">Copy iCal</button>
-                <span class="copy-status" aria-live="polite"></span>
-              </div>
-            </div>
-          </div>
+          <div class="calendar-cards" id="calendarCards"></div>
           
           <p>&nbsp;</p>
           
-          <table class="calendar-mini-table">
-          <tbody>
-          <tr style="height: 36px;">
-          <td style="width: 16.6667%; text-align: center; height: 36px;"><strong>Akce a srazy</strong></td>
-          <td style="width: 16.6667%; text-align: center; height: 36px;"><strong>CB závody</strong></td>
-          <td style="width: 16.6667%; text-align: center; height: 36px;"><strong>PMR závody</strong></td>
-          <td style="width: 16.6667%; text-align: center; height: 36px;"><strong>KV závody</strong></td>
-          <td style="width: 16.6667%; text-align: center; height: 36px;"><strong>VKV, UKV závody</strong></td>
-          </tr>
-          <tr style="height: 18px;">
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><a href="https://calendar.google.com/calendar/embed?src=hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com&amp;ctz=Europe%2FPrague"><img src="./url-icon.png" alt="URL" width="64" height="64" /></a><a href="https://calendar.google.com/calendar/ical/hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com/public/basic.ics"><img src="./ical-icon.png" alt="URL" width="64" height="64" /></a></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><a href="https://calendar.google.com/calendar/embed?src=eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com&amp;ctz=Europe%2FPrague"><img src="./url-icon.png" alt="URL" width="64" height="64" /></a><a href="https://calendar.google.com/calendar/ical/eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com/public/basic.ics"><img src="./ical-icon.png" alt="URL" width="64" height="64" /></a></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><a href="https://calendar.google.com/calendar/embed?src=0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com&amp;ctz=Europe%2FPrague"><img src="./url-icon.png" alt="URL" width="64" height="64" /></a><a href="https://calendar.google.com/calendar/ical/0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com/public/basic.ics"><img src="./ical-icon.png" alt="URL" width="64" height="64" /></a></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><a href="https://calendar.google.com/calendar/embed?src=iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com&amp;ctz=Europe%2FPrague"><img src="./url-icon.png" alt="URL" width="64" height="64" /></a><a href="https://calendar.google.com/calendar/ical/iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com/public/basic.ics"><img src="./ical-icon.png" alt="URL" width="64" height="64" /></a></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><a href="https://calendar.google.com/calendar/embed?src=muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com&amp;ctz=Europe%2FPrague"><img src="./url-icon.png" alt="URL" width="64" height="64" /></a><a href="https://calendar.google.com/calendar/ical/muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com/public/basic.ics"><img src="./ical-icon.png" alt="URL" width="64" height="64" /></a></td>
-          </tr>
-          <tr style="height: 18px;">
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><iframe title="Akce a srazy (agenda)" src="https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showDate=0&showPrint=0&showTabs=0&showCalendars=0&showTz=0&mode=AGENDA&src=aHU5YmpkaHZpOGExZ2dmMm1oNmN2ODUzaWtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%233F51B5" style="border-width:0" width="166" height="400" frameborder="0" scrolling="no"></iframe></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><iframe title="CB závody (agenda)" src="https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=ZW85OGM1Y2hlcnVzMGlha212djJtZjBuODRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%238E24AA" style="border-width:0" width="166" height="400" frameborder="0" scrolling="no"></iframe></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><iframe title="PMR závody (agenda)" src="https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=MGg2MmVvamhkZmpvaG9vMTVibGdqZmlhZzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23D81B60" style="border-width:0" width="166" height="400" frameborder="0" scrolling="no"></iframe></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><iframe title="KV závody (agenda)" src="https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=aXU0NGtwa2llNXY0NHBkYzFrbzBwNmxjM2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23F09300" style="border-width:0" width="166" height="400" frameborder="0" scrolling="no"></iframe></td>
-          <td style="width: 16.6667%; text-align: center; height: 18px;"><iframe title="VKV, UKV závody (agenda)" src="https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=bXVnYTU3dThuMGMxcTJtNmtqZXUxMWc5bmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23EF6C00" style="border-width:0" width="166" height="400" frameborder="0" scrolling="no"></iframe></td>
-          </tr>
-          </tbody>
-          </table>
+          <div class="calendar-mini-grid" id="calendarMiniGrid"></div>
           
           <p> </p>
 
-        <h2 id="line"> </h2>
+        <hr class="section-divider">
       <p><center> Created and maintained by OK2IKT, <span id="currentYear">2022</span> </center></p>
+      <script>
+        (function () {
+          var calendars = [
+            {
+              name: 'Akce a srazy',
+              embedSrc: 'https://calendar.google.com/calendar/embed?src=hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com&ctz=Europe%2FPrague',
+              icalSrc: 'https://calendar.google.com/calendar/ical/hu9bjdhvi8a1ggf2mh6cv853ik%40group.calendar.google.com/public/basic.ics',
+              agendaSrc: 'https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showDate=0&showPrint=0&showTabs=0&showCalendars=0&showTz=0&mode=AGENDA&src=aHU5YmpkaHZpOGExZ2dmMm1oNmN2ODUzaWtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%233F51B5'
+            },
+            {
+              name: 'CB závody',
+              embedSrc: 'https://calendar.google.com/calendar/embed?src=eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com&ctz=Europe%2FPrague',
+              icalSrc: 'https://calendar.google.com/calendar/ical/eo98c5cherus0iakmvv2mf0n84%40group.calendar.google.com/public/basic.ics',
+              agendaSrc: 'https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=ZW85OGM1Y2hlcnVzMGlha212djJtZjBuODRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%238E24AA'
+            },
+            {
+              name: 'PMR závody',
+              embedSrc: 'https://calendar.google.com/calendar/embed?src=0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com&ctz=Europe%2FPrague',
+              icalSrc: 'https://calendar.google.com/calendar/ical/0h62eojhdfjohoo15blgjfiag4%40group.calendar.google.com/public/basic.ics',
+              agendaSrc: 'https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=MGg2MmVvamhkZmpvaG9vMTVibGdqZmlhZzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23D81B60'
+            },
+            {
+              name: 'KV závody',
+              embedSrc: 'https://calendar.google.com/calendar/embed?src=iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com&ctz=Europe%2FPrague',
+              icalSrc: 'https://calendar.google.com/calendar/ical/iu44kpkie5v44pdc1ko0p6lc3k%40group.calendar.google.com/public/basic.ics',
+              agendaSrc: 'https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=aXU0NGtwa2llNXY0NHBkYzFrbzBwNmxjM2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23F09300'
+            },
+            {
+              name: 'VKV, UKV závody',
+              embedSrc: 'https://calendar.google.com/calendar/embed?src=muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com&ctz=Europe%2FPrague',
+              icalSrc: 'https://calendar.google.com/calendar/ical/muga57u8n0c1q2m6kjeu11g9nk%40group.calendar.google.com/public/basic.ics',
+              agendaSrc: 'https://calendar.google.com/calendar/embed?height=390&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FPrague&showTitle=0&showNav=0&showTabs=0&showCalendars=0&showTz=0&showDate=0&showPrint=0&mode=AGENDA&src=bXVnYTU3dThuMGMxcTJtNmtqZXUxMWc5bmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23EF6C00'
+            }
+          ];
+
+          function buildCalendarCards() {
+            var list = document.getElementById('calendarCards');
+            if (!list) return;
+            calendars.forEach(function (calendar) {
+              var card = document.createElement('div');
+              card.className = 'calendar-card';
+
+              var title = document.createElement('h3');
+              title.textContent = calendar.name;
+
+              var actions = document.createElement('div');
+              actions.className = 'calendar-actions';
+
+              var open = document.createElement('a');
+              open.className = 'btn';
+              open.href = calendar.embedSrc;
+              open.textContent = 'Otevřít';
+              open.setAttribute('aria-label', 'Otevřít kalendář ' + calendar.name + ' v Google Kalendáři');
+
+              var ical = document.createElement('a');
+              ical.className = 'btn';
+              ical.href = calendar.icalSrc;
+              ical.textContent = 'iCal';
+              ical.setAttribute('aria-label', 'Stáhnout iCal odkaz pro ' + calendar.name);
+
+              var copy = document.createElement('button');
+              copy.className = 'btn btn-copy';
+              copy.type = 'button';
+              copy.setAttribute('data-copy', calendar.icalSrc);
+              copy.setAttribute('aria-label', 'Zkopírovat iCal odkaz pro ' + calendar.name);
+              copy.textContent = 'Copy iCal';
+
+              var status = document.createElement('span');
+              status.className = 'copy-status';
+              status.setAttribute('aria-live', 'polite');
+
+              actions.appendChild(open);
+              actions.appendChild(ical);
+              actions.appendChild(copy);
+              actions.appendChild(status);
+              card.appendChild(title);
+              card.appendChild(actions);
+              list.appendChild(card);
+            });
+          }
+
+          function buildMiniCards() {
+            var list = document.getElementById('calendarMiniGrid');
+            if (!list) return;
+            calendars.forEach(function (calendar) {
+              var card = document.createElement('div');
+              card.className = 'calendar-mini-card';
+
+              var title = document.createElement('h3');
+              title.textContent = calendar.name;
+
+              var links = document.createElement('div');
+              links.className = 'calendar-mini-links';
+
+              var urlLink = document.createElement('a');
+              urlLink.href = calendar.embedSrc;
+              urlLink.setAttribute('aria-label', 'Otevřít mini kalendář ' + calendar.name);
+              var urlIcon = document.createElement('img');
+              urlIcon.src = './url-icon.png';
+              urlIcon.alt = 'Otevřít URL';
+              urlIcon.width = 40;
+              urlIcon.height = 40;
+              urlLink.appendChild(urlIcon);
+
+              var icalLink = document.createElement('a');
+              icalLink.href = calendar.icalSrc;
+              icalLink.setAttribute('aria-label', 'iCal odkaz pro ' + calendar.name);
+              var icalIcon = document.createElement('img');
+              icalIcon.src = './ical-icon.png';
+              icalIcon.alt = 'iCal odkaz';
+              icalIcon.width = 40;
+              icalIcon.height = 40;
+              icalLink.appendChild(icalIcon);
+
+              links.appendChild(urlLink);
+              links.appendChild(icalLink);
+
+              var frame = document.createElement('iframe');
+              frame.src = calendar.agendaSrc;
+              frame.title = calendar.name + ' (agenda)';
+              frame.setAttribute('loading', 'lazy');
+
+              card.appendChild(title);
+              card.appendChild(links);
+              card.appendChild(frame);
+              list.appendChild(card);
+            });
+          }
+
+          buildCalendarCards();
+          buildMiniCards();
+        })();
+      </script>
       <script>
         (function () {
           var el = document.getElementById('currentYear');


### PR DESCRIPTION
### Motivation
- Reduce duplicated HTML for calendar embeds by generating UI from a single data structure and improve maintainability.
- Improve accessibility by adding `aria-label`s and clearer control semantics.
- Make the mini-calendar area responsive and more usable on mobile by replacing the fixed table with stacked cards.
- Provide clear documentation for how to update calendars and deploy to GitHub Pages.

### Description
- Replaced the hard-coded calendar cards and mini-embed table in `index.html` with a single JavaScript array `calendars` and functions that dynamically build the quick-link cards and mini agenda cards (`buildCalendarCards` and `buildMiniCards`).
- Added `aria-label` attributes to action links and copy buttons, and retained the copy-to-clipboard logic so buttons update the `.copy-status` element on success/failure.
- Removed the old mini-calendar `<table>` and introduced responsive mini-cards and a grid layout, adding new CSS classes (`.calendar-mini-grid`, `.calendar-mini-card`, `.section-divider`) and style tweaks in `custom.css` including higher-contrast button styles.
- Added documentation to `README.md` with `Jak aktualizovat kalendáře` and `Jak nasadit na GitHub Pages` explaining where to edit the `calendars` array and how to publish the static site.

### Testing
- Started a local static server with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/index.html` to perform a visual check; a Playwright script visited the page and produced a screenshot artifact confirming the updated layout (succeeded).
- No unit or CI tests exist for this static site; commit was created successfully with `git commit` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972053ab0f4832ba6bd9ad6f934082d)