### PR TITLE
Update metadata and asset links to new GitHub Pages path

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="seznam akcí, závodů a ostatních CB/PMR/HAM aktivit" />
 <meta property="og:description" content="seznam akcí, závodů a ostatních CB/PMR/HAM aktivit" />
-<link rel="canonical" href="https://podly27.github.io/kalendar/" />
-<meta property="og:url" content="https://podly27.github.io/kalendar/" />
+<link rel="canonical" href="https://podly27.github.io/CB-PMR-HAM-kalendar/" />
+<meta property="og:url" content="https://podly27.github.io/CB-PMR-HAM-kalendar/" />
 <meta property="og:site_name" content="kalendar" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary" />
 <meta property="twitter:title" content="CB/PMR/HAM kalendář" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebSite","description":"seznam akcí, závodů a ostatních CB/PMR/HAM aktivit","headline":"CB/PMR/HAM kalendář","name":"kalendar","url":"https://podly27.github.io/kalendar/"}</script>
+{"@context":"https://schema.org","@type":"WebSite","description":"seznam akcí, závodů a ostatních CB/PMR/HAM aktivit","headline":"CB/PMR/HAM kalendář","name":"kalendar","url":"https://podly27.github.io/CB-PMR-HAM-kalendar/"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}?v=0442464a5cc481a3da8ca1491270c5d409a9e992">
-    <link rel="stylesheet" href="{{ '/custom.css' | relative_url }}">
+    <link rel="stylesheet" href="assets/css/style.css?v=0442464a5cc481a3da8ca1491270c5d409a9e992">
+    <link rel="stylesheet" href="custom.css">
     <!-- start custom head snippets, customize with your own _includes/head-custom.html file -->
 
 <!-- Setup Google Analytics -->
@@ -38,7 +38,7 @@
   </script>
 
 <!-- You can set your favicon here -->
-  <link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
+  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
 <!-- end custom head snippets -->
 


### PR DESCRIPTION
### Motivation
- The site was moved from `podly27.github.io/kalendar/` to `podly27.github.io/CB-PMR-HAM-kalendar/`, so canonical/OG/structured-data URLs needed updating to the new base path.
- Jekyll `relative_url` tags produced links that didn't resolve correctly for the static-hosted output, preventing styles and the favicon from loading.

### Description
- Update canonical and Open Graph `og:url` meta tags and the `WebSite` schema `url` to `https://podly27.github.io/CB-PMR-HAM-kalendar/` in `index.html`.
- Replace Liquid `relative_url` usages with static paths for assets in `index.html`, changing stylesheet and favicon links to `assets/css/style.css?v=...`, `custom.css`, and `favicon.ico` respectively.
- Adjust `README.md` primary site URL to `https://podly27.github.io/CB-PMR-HAM-kalendar/` to match the new site location.

### Testing
- No automated tests were run for these static HTML/CSS/README changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697211329090832ba60732bc3bf07d40)