### PR TITLE
Center calendar layout and constrain width

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -3,11 +3,13 @@
 
 .calendar-main {
   margin: 14px 0 6px;
+  display: flex;
+  justify-content: center;
 }
 
 .calendar-main iframe {
   width: 100%;
-  max-width: 1000px;
+  max-width: 920px;
   height: 70vh;
   min-height: 560px;
   border: 0;
@@ -18,6 +20,17 @@
 .calendar-main-link {
   margin: 8px 0 18px;
   text-align: center;
+}
+
+.markdown-body > p {
+  max-width: 920px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.container-lg {
+  max-width: 1100px;
 }
 
 .calendar-cards {
@@ -143,4 +156,3 @@
     grid-template-columns: 1fr;
   }
 }
-


### PR DESCRIPTION
### Motivation
- The calendar embed and surrounding content were too wide and hugged page edges, causing poor visual balance. 
- Paragraphs below the calendar were not centered and line lengths became excessive on large screens. 
- The goal is to improve layout readability by centering the main embed and constraining overall width.

### Description
- Updated `custom.css` to center the main calendar wrapper by setting `.calendar-main` to `display: flex` and `justify-content: center`.
- Reduced the embed maximum width from `1000px` to `920px` by changing `.calendar-main iframe { max-width: 920px; }`.
- Added a rule to limit paragraph width and center text under the calendar with `.markdown-body > p { max-width: 920px; margin-left: auto; margin-right: auto; text-align: center; }`.
- Constrained the overall page container by adding `.container-lg { max-width: 1100px; }`.

### Testing
- Served the static site with `python -m http.server 8000` and captured a layout screenshot using Playwright, which completed successfully and produced `artifacts/calendar-layout.png`.
- No automated unit tests exist for this static CSS change and no test failures occurred during the layout verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972158966c0832b821fde1780b4cb22)