### PR TITLE
Center content, update calendar URL text, and switch calendars to 5-column grids

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -22,20 +22,26 @@
   text-align: center;
 }
 
+.markdown-body {
+  text-align: center;
+}
+
 .markdown-body > p {
-  max-width: 920px;
+  max-width: 980px;
   margin-left: auto;
   margin-right: auto;
   text-align: center;
 }
 
 .container-lg {
-  max-width: 1100px;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .calendar-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(5, minmax(180px, 1fr));
   gap: 12px;
   margin: 10px 0 6px;
 }
@@ -45,6 +51,7 @@
   border-radius: 12px;
   padding: 12px 12px 10px;
   background: #ffffff;
+  text-align: center;
 }
 
 .calendar-card h3 {
@@ -57,6 +64,7 @@
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+  justify-content: center;
 }
 
 .btn {
@@ -101,7 +109,7 @@
 
 .calendar-mini-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(5, minmax(220px, 1fr));
   gap: 16px;
   margin: 12px 0 0;
 }
@@ -114,6 +122,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  text-align: center;
 }
 
 .calendar-mini-card h3 {
@@ -125,6 +134,7 @@
   display: flex;
   gap: 8px;
   align-items: center;
+  justify-content: center;
 }
 
 .calendar-mini-links img {
@@ -143,6 +153,14 @@
     height: 66vh;
     min-height: 520px;
   }
+
+  .calendar-cards {
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
+  }
+
+  .calendar-mini-grid {
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
+  }
 }
 
 @media (max-width: 720px) {
@@ -150,6 +168,10 @@
     height: 62vh;
     min-height: 480px;
     border-radius: 8px;
+  }
+
+  .calendar-cards {
+    grid-template-columns: 1fr;
   }
 
   .calendar-mini-grid {

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 
           <p>Pokud používáte Google Calendar nebo nějakou aplikaci v mobilu (Android/Apple) je možné si jednotlivé kalendáře importovat (viz odkazy níže) a potom podle potřeby zobrazovat atd. Je to daleko přehlednější.</p>
 
-          <p>Pracuje se na přesunu kalendáře na lepší adresu, která by měla být <a href="http://kalendar.svysilackou.cz">http://kalendar.svysilackou.cz</a>.</p>
+          <p>Kalendář najdete také na adrese: <a href="http://kalendar.svysilackou.cz">http://kalendar.svysilackou.cz</a>.</p>
 
           <h2 id="chcete-přidat-akci-nebo-závod-do-kalendáře-">Chcete přidat akci nebo závod do kalendáře ?</h2>
           <p>Pokud chcete přidat nějakou akci do kalendáře nebo máte dotaz nebo připomínku? Tak mne neváhejte kontaktovat ok2ikt(a)seznam.cz .</p>


### PR DESCRIPTION
### Motivation
- Make the site content centered and improve the desktop layout so the five quick-link panels and five mini calendars appear in aligned rows. 
- Clarify the calendar URL wording to point visitors to the new address directly. 
- Add sensible responsive fallbacks so the layout remains usable on smaller viewports.

### Description
- Replace the notice sentence in `index.html` to: "Kalendář najdete také na adrese: http://kalendar.svysilackou.cz". 
- Update `custom.css` to center `.markdown-body` text and increase paragraph max-width to `980px`. 
- Increase `.container-lg` max width to `1400px` and center it. 
- Force desktop grids to `repeat(5, ...)` for `.calendar-cards` and `.calendar-mini-grid`, center card contents with `text-align: center`, and center actions/links with `justify-content: center`. 
- Add responsive rules so at `max-width: 900px` the grids revert to two columns and at `max-width: 720px` they become single-column stacks.

### Testing
- Served the site locally with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/index.html` using a Playwright script which set the viewport to `1400x900` and captured `artifacts/kalendar-update.png`, and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697217d80be0832bb21221442e60fed7)