### PR TITLE
Add calendar link monitoring and widen main calendar embed

### DIFF
--- a/.github/workflows/link-monitor.yml
+++ b/.github/workflows/link-monitor.yml
@@ -1,0 +1,16 @@
+name: Link monitor
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify calendar links
+        run: scripts/check-links.sh

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Tento projekt je statický a běží na GitHub Pages bez build kroku.
 4. Počkejte na deploy – URL bude odpovídat nastavení v Pages.
 
 ## Další možné úpravy
-- [ ] **Monitoring odkazů** – krátký skript nebo GitHub Action, která ověří dostupnost iCal/URL odkazů.
+- [x] **Monitoring odkazů** – krátký skript nebo GitHub Action, která ověří dostupnost iCal/URL odkazů.

--- a/custom.css
+++ b/custom.css
@@ -9,7 +9,7 @@
 
 .calendar-main iframe {
   width: 100%;
-  max-width: 920px;
+  max-width: 1104px;
   height: 70vh;
   min-height: 560px;
   border: 0;

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+index_file="$root_dir/index.html"
+
+if [[ ! -f "$index_file" ]]; then
+  echo "index.html not found at $index_file" >&2
+  exit 1
+fi
+
+mapfile -t urls < <(
+  rg -o 'https://calendar\.google\.com/calendar/(embed|ical)/[^"\s]+' "$index_file" | sort -u
+)
+
+if [[ ${#urls[@]} -eq 0 ]]; then
+  echo "No calendar URLs found in $index_file" >&2
+  exit 1
+fi
+
+failures=0
+for url in "${urls[@]}"; do
+  status=$(curl -sS -o /dev/null -w "%{http_code}" -L "$url" || true)
+  if [[ "$status" =~ ^2|^3 ]]; then
+    echo "OK [$status] $url"
+  else
+    echo "FAIL [$status] $url" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ $failures -gt 0 ]]; then
+  echo "$failures link(s) failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Provide automated monitoring of the Google Calendar embed and iCal links to detect broken or unavailable calendars.
- Improve the layout by giving the main calendar iframe more horizontal space for larger screens.
- Reflect the new monitoring feature in the project documentation. 

### Description
- Added `scripts/check-links.sh`, a small shell script that extracts `https://calendar.google.com/.../embed` and `.../ical` URLs from `index.html` (using `rg`) and verifies them with `curl`, exiting non-zero if any link fails.
- Added a GitHub Actions workflow `.github/workflows/link-monitor.yml` that runs the check on a weekly schedule and supports manual `workflow_dispatch` runs.
- Increased the main calendar iframe `max-width` from `920px` to `1104px` in `custom.css` to widen the embed by ~20%.
- Marked the monitoring task as completed in `README.md`. 

### Testing
- Started a local static server with `python -m http.server` and captured a full-page screenshot with Playwright, which produced `artifacts/main-calendar.png` successfully. 
- Made the monitoring script executable with `chmod +x` and validated its presence and contents; no CI run of the workflow was performed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721a025c84832bbe4e94301ba533a3)