### PR TITLE
Expand main calendar width by 25%

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -9,7 +9,7 @@
 
 .calendar-main iframe {
   width: 100%;
-  max-width: 1104px;
+  max-width: 1380px;
   height: 70vh;
   min-height: 560px;
   border: 0;


### PR DESCRIPTION
### Motivation
- Increase the width of the main calendar embed to better use available space on larger screens.

### Description
- Update `custom.css` to set `.calendar-main iframe` `max-width` from `1104px` to `1380px`, making the main embed ~25% wider.

### Testing
- Launched a local `python -m http.server` and captured a visual verification screenshot at 1600x900 using Playwright saved to `artifacts/calendar-main.png`, which confirms the wider embed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721e0642e4832b83b46559796eadab)